### PR TITLE
Support for retrieving a single address

### DIFF
--- a/src/Contracts/LookupService.php
+++ b/src/Contracts/LookupService.php
@@ -3,14 +3,15 @@
 
 namespace RicorocksDigitalAgency\GoingPostal\Contracts;
 
-use Illuminate\Contracts\Support\Arrayable;
+
 use Illuminate\Support\Collection;
+use RicorocksDigitalAgency\GoingPostal\Address;
 
 interface LookupService
 {
 
     public function lookup($postcode): Collection;
 
-    public function addressFor($identifier): Arrayable;
+    public function addressFor($identifier): Address;
 
 }

--- a/src/Contracts/LookupService.php
+++ b/src/Contracts/LookupService.php
@@ -10,7 +10,7 @@ use RicorocksDigitalAgency\GoingPostal\Address;
 interface LookupService
 {
 
-    public function lookup($postcode): Collection;
+    public function addressesIn($postcode): Collection;
 
     public function addressFor($identifier): Address;
 

--- a/src/Contracts/LookupService.php
+++ b/src/Contracts/LookupService.php
@@ -3,15 +3,14 @@
 
 namespace RicorocksDigitalAgency\GoingPostal\Contracts;
 
-
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
-use RicorocksDigitalAgency\GoingPostal\Address;
 
 interface LookupService
 {
 
     public function lookup($postcode): Collection;
 
-    public function addressFor($identifier): Address;
+    public function addressFor($identifier): Arrayable;
 
 }

--- a/src/Contracts/LookupService.php
+++ b/src/Contracts/LookupService.php
@@ -5,10 +5,13 @@ namespace RicorocksDigitalAgency\GoingPostal\Contracts;
 
 
 use Illuminate\Support\Collection;
+use RicorocksDigitalAgency\GoingPostal\Address;
 
 interface LookupService
 {
 
     public function lookup($postcode): Collection;
+
+    public function addressFor($identifier): Address;
 
 }

--- a/src/Facades/GoingPostal.php
+++ b/src/Facades/GoingPostal.php
@@ -6,12 +6,14 @@ namespace RicorocksDigitalAgency\GoingPostal\Facades;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
+use RicorocksDigitalAgency\GoingPostal\Address;
 
 /**
  * Class GoingPostal
  * @package RicorocksDigitalAgency\GoingPostal\Facades
  *
- * @method static Collection lookup($postcode)
+ * @method static Collection lookup($postcode) Return addresses for the given postcode
+ * @method static Address addressFor($identifier) Retrieve a single address from an identifier
  */
 class GoingPostal extends Facade
 {

--- a/src/Facades/GoingPostal.php
+++ b/src/Facades/GoingPostal.php
@@ -6,14 +6,14 @@ namespace RicorocksDigitalAgency\GoingPostal\Facades;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
-use RicorocksDigitalAgency\GoingPostal\Address;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * Class GoingPostal
  * @package RicorocksDigitalAgency\GoingPostal\Facades
  *
  * @method static Collection lookup($postcode) Return addresses for the given postcode
- * @method static Address addressFor($identifier) Retrieve a single address from an identifier
+ * @method static Arrayable addressFor($identifier) Retrieve a single address from an identifier
  */
 class GoingPostal extends Facade
 {

--- a/src/Facades/GoingPostal.php
+++ b/src/Facades/GoingPostal.php
@@ -6,14 +6,14 @@ namespace RicorocksDigitalAgency\GoingPostal\Facades;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Contracts\Support\Arrayable;
+use RicorocksDigitalAgency\GoingPostal\Address;
 
 /**
  * Class GoingPostal
  * @package RicorocksDigitalAgency\GoingPostal\Facades
  *
  * @method static Collection lookup($postcode) Return addresses for the given postcode
- * @method static Arrayable addressFor($identifier) Retrieve a single address from an identifier
+ * @method static Address addressFor($identifier) Retrieve a single address from an identifier
  */
 class GoingPostal extends Facade
 {

--- a/src/Facades/GoingPostal.php
+++ b/src/Facades/GoingPostal.php
@@ -12,7 +12,7 @@ use RicorocksDigitalAgency\GoingPostal\Address;
  * Class GoingPostal
  * @package RicorocksDigitalAgency\GoingPostal\Facades
  *
- * @method static Collection lookup($postcode) Return addresses for the given postcode
+ * @method static Collection addressesIn($postcode) Return addresses for the given postcode
  * @method static Address addressFor($identifier) Retrieve a single address from an identifier
  */
 class GoingPostal extends Facade

--- a/src/GoingPostal.php
+++ b/src/GoingPostal.php
@@ -17,4 +17,9 @@ class GoingPostal
         return $this->lookupService->lookup($postcode);
     }
 
+    public function addressFor($identifier)
+    {
+        return $this->lookupService->addressFor($identifier);
+    }
+
 }

--- a/src/GoingPostal.php
+++ b/src/GoingPostal.php
@@ -12,9 +12,9 @@ class GoingPostal
     {
     }
 
-    public function lookup($postcode)
+    public function addressesIn($postcode)
     {
-        return $this->lookupService->lookup($postcode);
+        return $this->lookupService->addressesIn($postcode);
     }
 
     public function addressFor($identifier)

--- a/src/Http/Livewire/Traits/SearchesPostcodes.php
+++ b/src/Http/Livewire/Traits/SearchesPostcodes.php
@@ -14,7 +14,7 @@ trait SearchesPostcodes
     public function searchPostcode()
     {
         $this->validate(['postcode' => 'required|max:10|min:4']);
-        $results = GoingPostal::lookup($this->postcode);
+        $results = GoingPostal::addressesIn($this->postcode);
         $this->emit('going-postal.addresses-received', $results->toArray());
         return $results;
     }

--- a/src/Http/Livewire/Traits/SearchesPostcodes.php
+++ b/src/Http/Livewire/Traits/SearchesPostcodes.php
@@ -9,12 +9,22 @@ use RicorocksDigitalAgency\GoingPostal\Facades\GoingPostal;
 trait SearchesPostcodes
 {
     public $postcode = '';
+    public $addressIdentifier = null;
 
     public function searchPostcode()
     {
         $this->validate(['postcode' => 'required|max:10|min:4']);
         $results = GoingPostal::lookup($this->postcode);
         $this->emit('going-postal.addresses-received', $results->toArray());
+        return $results;
+    }
+
+    public function retrieveAddress()
+    {
+        $this->validate(['addressIdentifier' => 'required']);
+        $address = GoingPostal::addressFor($this->addressIdentifier);
+        $this->emit('going-postal.address-received', $address->toArray());
+        return $address;
     }
 
 }

--- a/src/Providers/GoingPostalServiceProvider.php
+++ b/src/Providers/GoingPostalServiceProvider.php
@@ -5,11 +5,9 @@ namespace RicorocksDigitalAgency\GoingPostal\Providers;
 
 
 use Illuminate\Support\ServiceProvider;
-use Livewire\Livewire;
-use RicorocksDigitalAgency\GoingPostal\Contracts\LookupService;
 use RicorocksDigitalAgency\GoingPostal\GoingPostal;
+use RicorocksDigitalAgency\GoingPostal\Contracts\LookupService;
 use RicorocksDigitalAgency\GoingPostal\Services\FakeLookupService;
-use \RicorocksDigitalAgency\GoingPostal\Http;
 
 class GoingPostalServiceProvider extends ServiceProvider
 {

--- a/src/Services/FakeLookupService.php
+++ b/src/Services/FakeLookupService.php
@@ -33,4 +33,15 @@ class FakeLookupService implements LookupService
                 ->postcode($postcode);
         });
     }
+
+    public function addressFor($identifier): Address
+    {
+        return Address::make()
+            ->line1($this->faker->streetAddress)
+            ->line2($this->faker->streetName)
+            ->city($this->faker->city)
+            ->county($this->faker->state)
+            ->country("United Kingdom")
+            ->postcode($this->faker->postcode);
+    }
 }

--- a/src/Services/FakeLookupService.php
+++ b/src/Services/FakeLookupService.php
@@ -21,7 +21,7 @@ class FakeLookupService implements LookupService
         $this->numberOfAddresses = $numberOfAddresses;
     }
 
-    public function lookup($postcode): Collection
+    public function addressesIn($postcode): Collection
     {
         return Collection::times($this->numberOfAddresses, function() use ($postcode) {
             return Address::make()

--- a/tests/GoingPostalFacadeTest.php
+++ b/tests/GoingPostalFacadeTest.php
@@ -21,4 +21,12 @@ class GoingPostalFacadeTest extends TestCase
         $results->each(fn($result) => expect($result)->toBeInstanceOf(Address::class));
     }
 
+    /** @test */
+    public function it_can_retrieve_an_address_from_an_identifier()
+    {
+        $address = GoingPostal::addressFor($this->faker->uuid);
+
+        expect($address)->toBeInstanceOf(Address::class);
+    }
+
 }

--- a/tests/GoingPostalFacadeTest.php
+++ b/tests/GoingPostalFacadeTest.php
@@ -15,7 +15,7 @@ class GoingPostalFacadeTest extends TestCase
     /** @test */
     public function it_can_lookup_a_given_postcode()
     {
-        $results = GoingPostal::lookup($this->faker->postcode);
+        $results = GoingPostal::addressesIn($this->faker->postcode);
 
         expect($results)->toHaveCount(5);
         $results->each(fn($result) => expect($result)->toBeInstanceOf(Address::class));

--- a/tests/Livewire/GoingPostalComponentTest.php
+++ b/tests/Livewire/GoingPostalComponentTest.php
@@ -17,7 +17,7 @@ class GoingPostalComponentTest extends TestCase
     /** @test */
     public function it_calls_on_the_service_with_the_given_postcode()
     {
-        GoingPostal::shouldReceive('lookup')
+        GoingPostal::shouldReceive('addressesIn')
             ->once()
             ->with('foobar')
             ->andReturn(collect());
@@ -50,7 +50,7 @@ class GoingPostalComponentTest extends TestCase
             Address::make()->line1('Foo')->line2('Bar')->city('Baz')->county('Blah')->postcode('Foobar')->toArray(),
         ];
 
-        GoingPostal::shouldReceive('lookup')->andReturn(Collection::wrap($payload));
+        GoingPostal::shouldReceive('addressesIn')->andReturn(Collection::wrap($payload));
 
         static::livewire()
             ->set('postcode', 'Foobar')

--- a/tests/Livewire/GoingPostalComponentTest.php
+++ b/tests/Livewire/GoingPostalComponentTest.php
@@ -4,17 +4,16 @@
 namespace RicorocksDigitalAgency\GoingPostal\Tests\Livewire;
 
 
-use Illuminate\Support\Collection;
-use Livewire\Component;
 use Livewire\Livewire;
+use Livewire\Component;
+use Illuminate\Support\Collection;
 use RicorocksDigitalAgency\GoingPostal\Address;
+use RicorocksDigitalAgency\GoingPostal\Tests\TestCase;
 use RicorocksDigitalAgency\GoingPostal\Facades\GoingPostal;
 use RicorocksDigitalAgency\GoingPostal\Http\Livewire\Traits\SearchesPostcodes;
-use RicorocksDigitalAgency\GoingPostal\Tests\TestCase;
 
 class GoingPostalComponentTest extends TestCase
 {
-
     /** @test */
     public function it_calls_on_the_service_with_the_given_postcode()
     {
@@ -104,7 +103,6 @@ class GoingPostalComponentTest extends TestCase
     {
         return Livewire::test(TestComponent::class);
     }
-
 }
 
 class TestComponent extends Component {


### PR DESCRIPTION
@lukeraymonddowning, if you're happy with the syntax, what do you think to making `lookup => addressesIn`? To remove any ambiguity now that we have two retrieval methods?